### PR TITLE
Files need to be read as buffer

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -84,7 +84,12 @@ function serveFile(userDir, repo, filePath, res) {
     return res.send(404, 'File not found');
   }
   res.type(mime.lookup(fileToServe));
-  return res.send(200, fs.readFileSync(fileToServe, { encoding: 'utf-8' }));
+  try {
+    var file = fs.readFileSync(fileToServe);
+    return res.send(200, file);
+  } catch (e) {
+    return res.send(404, 'File not found');
+  }
 };
 
 /**


### PR DESCRIPTION
Remove encoding to avoid problems and use directly the buffer instead.
Also wrapped the `resdFileSync` in a try/catch in case file cannot be read.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/virtru/component-ssh-proxy-install/3)

<!-- Reviewable:end -->
